### PR TITLE
Rework textfield

### DIFF
--- a/core/src/main/java/org/yggard/brokkgui/behavior/GuiTextfieldBehavior.java
+++ b/core/src/main/java/org/yggard/brokkgui/behavior/GuiTextfieldBehavior.java
@@ -188,7 +188,8 @@ public class GuiTextfieldBehavior<T extends GuiTextfield> extends GuiBehaviorBas
         return pos;
     }
     
-    protected int nextWordPosition() {
+    protected int nextWordPosition() 
+    {
         if(getModel().getCursorPosition() == getModel().getText().length())
             return getModel().getCursorPosition();
         String text = getModel().getText();

--- a/core/src/main/java/org/yggard/brokkgui/behavior/GuiTextfieldBehavior.java
+++ b/core/src/main/java/org/yggard/brokkgui/behavior/GuiTextfieldBehavior.java
@@ -1,5 +1,7 @@
 package org.yggard.brokkgui.behavior;
 
+import java.util.regex.Pattern;
+
 import org.yggard.brokkgui.BrokkGuiPlatform;
 import org.yggard.brokkgui.element.GuiTextfield;
 import org.yggard.brokkgui.event.CursorMoveEvent;
@@ -28,17 +30,33 @@ public class GuiTextfieldBehavior<T extends GuiTextfield> extends GuiBehaviorBas
         if (event.getKey() == this.keyboard.getKeyCode("DELETE"))
         {
             if (this.getModel().isEditable())
-                contentChanged = this.deleteAfterCursor();
+            {
+                if(keyboard.isCtrlKeyDown())
+                    contentChanged = this.deleteWordAfterCursor();
+                else
+                    contentChanged = this.deleteAfterCursor();
+            }
         }
         else if (event.getKey() == this.keyboard.getKeyCode("BACK"))
         {
             if (this.getModel().isEditable())
-                contentChanged = this.deleteFromCursor();
+            {
+                if(keyboard.isCtrlKeyDown())
+                    contentChanged = this.deleteWordBeforeCursor();
+                else
+                    contentChanged = this.deleteFromCursor();
+            }
         }
         else if (event.getKey() == this.keyboard.getKeyCode("LEFT"))
-            this.setCursorPosition(this.getModel().getCursorPosition() - 1);
+            if(keyboard.isCtrlKeyDown())
+                this.setCursorPosition(this.previousWordPosition());
+            else
+                this.setCursorPosition(this.getModel().getCursorPosition() - 1);
         else if (event.getKey() == this.keyboard.getKeyCode("RIGHT"))
-            this.setCursorPosition(this.getModel().getCursorPosition() + 1);
+            if(keyboard.isCtrlKeyDown())
+                this.setCursorPosition(this.nextWordPosition());
+            else
+                this.setCursorPosition(this.getModel().getCursorPosition() + 1);
         else if (event.getKey() == this.keyboard.getKeyCode("V")
                 && BrokkGuiPlatform.getInstance().getKeyboardUtil().isCtrlKeyDown())
         {
@@ -129,4 +147,95 @@ public class GuiTextfieldBehavior<T extends GuiTextfield> extends GuiBehaviorBas
             this.getModel().setCursorPosition(cursorPosition);
         }
     }
+    
+    private static final Pattern alphaNumRegex = Pattern.compile("[a-zA-Z0-9]");
+    
+    protected int previousWordPosition() 
+    {
+        String textBeforeCursor = getModel().getText().substring(0, getModel().getCursorPosition());
+        if(textBeforeCursor.isEmpty())
+            return 0;
+        int pos = getModel().getCursorPosition();
+        
+        boolean foundCharacter = false;
+        while(pos > 0) 
+        {
+            String charAtPos = textBeforeCursor.charAt(pos - 1) + "";
+            if(alphaNumRegex.matcher(charAtPos).matches()) 
+            {
+                foundCharacter = true;
+                pos--;
+            }
+            else if(charAtPos.equals(" ")) 
+            {
+                if(foundCharacter)
+                    break;
+                else
+                    pos--;
+            }
+            else if(pos == getModel().getCursorPosition()) 
+            {
+                pos--;
+                break;
+            } 
+            else 
+            {
+                pos--;
+            }
+        }
+        
+        return pos;
+    }
+    
+    protected int nextWordPosition() {
+        if(getModel().getCursorPosition() == getModel().getText().length())
+            return getModel().getCursorPosition();
+        String text = getModel().getText();
+        int pos = getModel().getCursorPosition();
+        boolean foundSpace = false;
+        while(pos < getModel().getText().length())
+        {
+            String charAtPos = text.charAt(pos) + "";
+            if(charAtPos.equals(" ")) 
+            {
+                foundSpace = true;
+                pos++;
+            }
+            else if(foundSpace) 
+            {
+                break;
+            } 
+            else if(!alphaNumRegex.matcher(charAtPos).matches() && pos != getModel().getCursorPosition())
+            {
+                break;
+            }
+            else
+            {
+                pos++;
+            }
+        }
+        return pos;
+    }
+    
+    protected boolean deleteWordBeforeCursor() 
+    {
+        if(this.getModel().getCursorPosition() == 0)
+            return false;
+        int pos = previousWordPosition();
+        String currentText = this.getModel().getText();
+        this.getModel().setText(currentText.substring(0, pos) + currentText.substring(this.getModel().getCursorPosition()));
+        this.setCursorPosition(pos);
+        return true;
+    }
+    
+    protected boolean deleteWordAfterCursor()
+    {
+        if(this.getModel().getCursorPosition() == this.getModel().getText().length())
+            return false;
+        int pos = nextWordPosition();
+        String currentText = this.getModel().getText();
+        this.getModel().setText(currentText.substring(0, getModel().getCursorPosition()) + currentText.substring(pos));
+        return true;
+    }
+    
 }

--- a/core/src/main/java/org/yggard/brokkgui/behavior/GuiTextfieldBehavior.java
+++ b/core/src/main/java/org/yggard/brokkgui/behavior/GuiTextfieldBehavior.java
@@ -14,6 +14,9 @@ import org.yggard.brokkgui.internal.IKeyboardUtil;
  */
 public class GuiTextfieldBehavior<T extends GuiTextfield> extends GuiBehaviorBase<T>
 {
+    
+    static final Pattern ALPHA_NUM_REGEX = Pattern.compile("[a-zA-Z0-9]");
+    
     private final IKeyboardUtil keyboard = BrokkGuiPlatform.getInstance().getKeyboardUtil();
 
     public GuiTextfieldBehavior(final T model)
@@ -148,8 +151,6 @@ public class GuiTextfieldBehavior<T extends GuiTextfield> extends GuiBehaviorBas
         }
     }
     
-    private static final Pattern alphaNumRegex = Pattern.compile("[a-zA-Z0-9]");
-    
     protected int previousWordPosition() 
     {
         String textBeforeCursor = getModel().getText().substring(0, getModel().getCursorPosition());
@@ -161,7 +162,7 @@ public class GuiTextfieldBehavior<T extends GuiTextfield> extends GuiBehaviorBas
         while(pos > 0) 
         {
             String charAtPos = textBeforeCursor.charAt(pos - 1) + "";
-            if(alphaNumRegex.matcher(charAtPos).matches()) 
+            if(ALPHA_NUM_REGEX.matcher(charAtPos).matches()) 
             {
                 foundCharacter = true;
                 pos--;
@@ -205,7 +206,7 @@ public class GuiTextfieldBehavior<T extends GuiTextfield> extends GuiBehaviorBas
             {
                 break;
             } 
-            else if(!alphaNumRegex.matcher(charAtPos).matches() && pos != getModel().getCursorPosition())
+            else if(!ALPHA_NUM_REGEX.matcher(charAtPos).matches() && pos != getModel().getCursorPosition())
             {
                 break;
             }

--- a/core/src/main/java/org/yggard/brokkgui/element/GuiTextfield.java
+++ b/core/src/main/java/org/yggard/brokkgui/element/GuiTextfield.java
@@ -19,13 +19,14 @@ import java.util.List;
  */
 public class GuiTextfield extends GuiControl implements ITextInput
 {
-    private final BaseProperty<String>                textProperty, promptTextProperty;
+    private final BaseProperty<String>                textProperty, promptTextProperty, promptEllipsisProperty;
 
     private final BaseProperty<Boolean>               promptTextAlwaysDisplayedProperty, editableProperty,
             validatedProperty;
 
     private final BaseProperty<Integer>               maxTextLengthProperty;
     private final BaseProperty<Integer>               cursorPositionProperty;
+    private final BaseProperty<Float>                 textPaddingProperty;
 
     private final BaseListProperty<BaseTextValidator> validatorsProperty;
 
@@ -38,9 +39,11 @@ public class GuiTextfield extends GuiControl implements ITextInput
 
         this.textProperty = new BaseProperty<>(text, "textProperty");
         this.promptTextProperty = new BaseProperty<>("", "promptTextProperty");
+        this.promptEllipsisProperty = new BaseProperty<>("...", "promptEllipsisProperty");
 
         this.maxTextLengthProperty = new BaseProperty<>(-1, "maxTextLength");
         this.cursorPositionProperty = new BaseProperty<>(0, "cursorPositionProperty");
+        this.textPaddingProperty = new BaseProperty<>(2.0f, "textPaddingProperty");
 
         this.promptTextAlwaysDisplayedProperty = new BaseProperty<>(false, "promptTextAlwaysDisplayedProperty");
         this.editableProperty = new BaseProperty<>(true, "editableProperty");
@@ -100,6 +103,16 @@ public class GuiTextfield extends GuiControl implements ITextInput
     public BaseProperty<Integer> getCursorPositionProperty()
     {
         return this.cursorPositionProperty;
+    }
+    
+    public BaseProperty<Float> getTextPaddingProperty()
+    {
+        return this.textPaddingProperty;
+    }
+    
+    public BaseProperty<String> getPromptEllipsisProperty()
+    {
+        return this.promptEllipsisProperty;
     }
 
     @Override
@@ -212,6 +225,26 @@ public class GuiTextfield extends GuiControl implements ITextInput
     public void setPromptTextAlwaysDisplayed(final boolean always)
     {
         this.getPromptTextAlwaysDisplayedProperty().setValue(always);
+    }
+    
+    public void setPromptEllipsis(String ellipsis) 
+    {
+        this.getPromptEllipsisProperty().setValue(ellipsis);
+    }
+    
+    public String getPromptEllipsis()
+    {
+        return this.getPromptEllipsisProperty().getValue();
+    }
+    
+    public void setTextPadding(float padding)
+    {
+        this.getTextPaddingProperty().setValue(padding);
+    }
+    
+    public float getTextPadding()
+    {
+        return this.getTextPaddingProperty().getValue();
     }
 
     ////////////

--- a/core/src/main/java/org/yggard/brokkgui/skin/GuiTextfieldSkin.java
+++ b/core/src/main/java/org/yggard/brokkgui/skin/GuiTextfieldSkin.java
@@ -1,23 +1,49 @@
 package org.yggard.brokkgui.skin;
 
 import org.apache.commons.lang3.StringUtils;
+import org.yggard.brokkgui.BrokkGuiPlatform;
 import org.yggard.brokkgui.behavior.GuiTextfieldBehavior;
 import org.yggard.brokkgui.element.GuiTextfield;
+import org.yggard.brokkgui.internal.IGuiHelper;
 import org.yggard.brokkgui.internal.IGuiRenderer;
 import org.yggard.brokkgui.paint.Color;
 import org.yggard.brokkgui.paint.RenderPass;
 import org.yggard.brokkgui.validation.BaseTextValidator;
+
+import fr.ourten.teabeans.binding.BaseBinding;
+import fr.ourten.teabeans.value.BaseProperty;
 
 /**
  * @author Ourten 2 oct. 2016
  */
 public class GuiTextfieldSkin<T extends GuiTextfield> extends GuiBehaviorSkinBase<T, GuiTextfieldBehavior<T>>
 {
+    
+    private final BaseProperty<String> ellipsedPromptProperty;
+    
     public GuiTextfieldSkin(final T model, final GuiTextfieldBehavior<T> behaviour)
     {
         super(model, behaviour);
 
         this.getModel().getStyle().registerProperty("-text-color", Color.WHITE, Color.class);
+        
+        this.ellipsedPromptProperty = new BaseProperty<>("", "ellipsedPromptProperty");
+        
+        this.ellipsedPromptProperty.bind(new BaseBinding<String>()
+        {
+            {
+                super.bind(getModel().getPrompTextProperty(), getModel().getPromptEllipsisProperty(),
+                        getModel().getTextPaddingProperty(), getModel().getWidthProperty());
+            }
+            
+            @Override
+            public String computeValue() {
+                return trimTextToWidth(getModel().getPromptText(), getModel().getPromptEllipsisProperty().getValue(),
+                        (int) (getModel().getWidth() - getModel().getTextPaddingProperty().getValue() * 2), 
+                        BrokkGuiPlatform.getInstance().getGuiHelper());
+            }
+            
+        });
     }
 
     @Override
@@ -36,30 +62,31 @@ public class GuiTextfieldSkin<T extends GuiTextfield> extends GuiBehaviorSkinBas
                 if (!StringUtils.isEmpty(this.getModel().getPromptText())
                         && (this.getModel().isPromptTextAlwaysDisplayed()
                                 || StringUtils.isEmpty(this.getModel().getText())))
-                    renderer.getHelper().drawString(this.getModel().getPromptText(), x + 3, y + 3,
-                            this.getModel().getzLevel(), color.shade(0.5f));
+                    renderer.getHelper().drawString(this.ellipsedPromptProperty.getValue(), x + getModel().getTextPadding(),
+                            y + getModel().getTextPadding(), this.getModel().getzLevel(), color.shade(0.5f));
                 if (this.getModel().getCursorPosition() == this.getModel().getText().length())
                     renderer.getHelper().drawColoredRect(renderer,
-                            x + 4 + renderer.getHelper().getStringWidth(
+                            x + getModel().getTextPadding() + 1 + renderer.getHelper().getStringWidth(
                                     this.getModel().getText().substring(0, this.getModel().getCursorPosition())),
-                            y + renderer.getHelper().getStringHeight() + 2, 5, 1, this.getModel().getzLevel(),
-                            color.shade(0.7f));
-                renderer.getHelper().drawString(this.getModel().getText(), x + 3 + 1, y + 3 + 1,
-                        this.getModel().getzLevel(), color.shade(0.7f));
+                            y + renderer.getHelper().getStringHeight() + getModel().getTextPadding() - 1, 5, 1,
+                            this.getModel().getzLevel(), color.shade(0.7f));
+                renderer.getHelper().drawString(this.getModel().getText(), x + getModel().getTextPadding() + 1, 
+                        y + getModel().getTextPadding() + 1, this.getModel().getzLevel(), color.shade(0.7f));
 
                 if (this.getModel().getCursorPosition() != this.getModel().getText().length())
                     renderer.getHelper().drawColoredRect(renderer,
-                            x + 3 + renderer.getHelper().getStringWidth(
+                            x + getModel().getTextPadding() + renderer.getHelper().getStringWidth(
                                     this.getModel().getText().substring(0, this.getModel().getCursorPosition())),
-                            y + 2, 1, renderer.getHelper().getStringHeight() + 1, this.getModel().getzLevel(),
-                            color.shade(0.3f));
+                            y + getModel().getTextPadding() - 1, 1, renderer.getHelper().getStringHeight() + 1,
+                            this.getModel().getzLevel(), color.shade(0.3f));
                 else
                     renderer.getHelper().drawColoredRect(renderer,
-                            x + 3 + renderer.getHelper().getStringWidth(
+                            x + getModel().getTextPadding() + renderer.getHelper().getStringWidth(
                                     this.getModel().getText().substring(0, this.getModel().getCursorPosition())),
                             y + renderer.getHelper().getStringHeight() + 1, 5, 1, this.getModel().getzLevel(),
                             color.shade(0.3f));
-                renderer.getHelper().drawString(this.getModel().getText(), x + 3, y + 3, this.getModel().getzLevel(),
+                renderer.getHelper().drawString(this.getModel().getText(), x + getModel().getTextPadding(),
+                        y + getModel().getTextPadding(), this.getModel().getzLevel(),
                         color);
             }
             else if (pass == RenderPass.SPECIAL)
@@ -85,4 +112,17 @@ public class GuiTextfieldSkin<T extends GuiTextfield> extends GuiBehaviorSkinBas
     {
         return this.getModel().getStyle().getStyleProperty("-text-color", Color.class).getValue();
     }
+    
+    public String trimTextToWidth(String textToTrim, String ellips, int width, IGuiHelper helper) {
+        String trimmed = helper.trimStringToPixelWidth(textToTrim, width);
+        if(!trimmed.equals(textToTrim))
+        {
+            if(trimmed.length() >= ellips.length())
+                trimmed = trimmed.substring(0, trimmed.length() - ellips.length()) + ellips;
+            else
+                trimmed = "";
+        }
+        return trimmed;
+    }
+    
 }

--- a/core/src/main/java/org/yggard/brokkgui/skin/GuiTextfieldSkin.java
+++ b/core/src/main/java/org/yggard/brokkgui/skin/GuiTextfieldSkin.java
@@ -52,8 +52,7 @@ public class GuiTextfieldSkin<T extends GuiTextfield> extends GuiBehaviorSkinBas
         });
         
         displayOffsetProperty.bind(new BaseBinding<Integer>() 
-        {
-            
+        {   
             {
                 super.bind(getModel().getCursorPositionProperty(), getModel().getTextPaddingProperty(), getModel().getWidthProperty());
             }
@@ -69,7 +68,7 @@ public class GuiTextfieldSkin<T extends GuiTextfield> extends GuiBehaviorSkinBas
                 IGuiHelper helper = BrokkGuiPlatform.getInstance().getGuiHelper();
                 while(helper.getStringWidth(getModel().getText().substring(
                         displayOffset, 
-                        getModel().getCursorPosition())) > getModel().getWidth() - 2 * getModel().getTextPaddingProperty().getValue())
+                        getModel().getCursorPosition())) > getModel().getWidth() - 2 * getModel().getTextPadding())
                 {
                     displayOffset++;
                 }
@@ -90,7 +89,7 @@ public class GuiTextfieldSkin<T extends GuiTextfield> extends GuiBehaviorSkinBas
             {
                 String rightPart = getModel().getText().substring(displayOffsetProperty.getValue());
                 IGuiHelper helper = BrokkGuiPlatform.getInstance().getGuiHelper();
-                while(helper.getStringWidth(rightPart) > getModel().getWidth() - 2 * getModel().getTextPaddingProperty().getValue())
+                while(helper.getStringWidth(rightPart) > getModel().getWidth() - 2 * getModel().getTextPadding())
                 {
                     rightPart = rightPart.substring(0, rightPart.length() - 1);
                 }
@@ -113,7 +112,6 @@ public class GuiTextfieldSkin<T extends GuiTextfield> extends GuiBehaviorSkinBas
                 final float x = this.getModel().getxPos() + this.getModel().getxTranslate();
                 final float y = this.getModel().getyPos() + this.getModel().getyTranslate();
                 final float padding = this.getModel().getTextPadding();
-
                 // Prompt text
                 if (!StringUtils.isEmpty(this.getModel().getPromptText())
                         && (this.getModel().isPromptTextAlwaysDisplayed()
@@ -123,11 +121,9 @@ public class GuiTextfieldSkin<T extends GuiTextfield> extends GuiBehaviorSkinBas
                             y + this.getModel().getTextPaddingProperty().getValue(),
                             this.getModel().getzLevel(), color.shade(0.5f));
                 }
-                
-                // Text shadow
-                renderer.getHelper().drawString(this.displayedTextProperty.getValue(), x + padding + 1, 
-                        y + padding + 1, this.getModel().getzLevel(), color.shade(0.7f));
-                
+                // Text
+                renderer.getHelper().drawString(this.displayedTextProperty.getValue(), x + padding,
+                        y + padding, this.getModel().getzLevel(), color, color.shade(0.7f)); 
                 // Cursor
                 if (this.getModel().getFocusedProperty().getValue())
                 {
@@ -136,11 +132,7 @@ public class GuiTextfieldSkin<T extends GuiTextfield> extends GuiBehaviorSkinBas
                                     this.getModel().getText().substring(this.displayOffsetProperty.getValue(),
                                             this.getModel().getCursorPosition())), y + padding - 1, 1, 
                             renderer.getHelper().getStringHeight() + 1, this.getModel().getzLevel(), color.shade(0.3f));
-                }
-                
-                // Text
-                renderer.getHelper().drawString(this.displayedTextProperty.getValue(), x + padding,
-                        y + padding, this.getModel().getzLevel(), color);
+                }  
             }
             else if (pass == RenderPass.SPECIAL)
                 if (!this.getModel().isValid())
@@ -166,12 +158,13 @@ public class GuiTextfieldSkin<T extends GuiTextfield> extends GuiBehaviorSkinBas
         return this.getModel().getStyle().getStyleProperty("-text-color", Color.class).getValue();
     }
     
-    public String trimTextToWidth(String textToTrim, String ellips, int width, IGuiHelper helper) {
+    public String trimTextToWidth(String textToTrim, String ellipsis, int width, IGuiHelper helper) 
+    {
         String trimmed = helper.trimStringToPixelWidth(textToTrim, width);
         if(!trimmed.equals(textToTrim))
         {
-            if(trimmed.length() >= ellips.length())
-                trimmed = trimmed.substring(0, trimmed.length() - ellips.length()) + ellips;
+            if(trimmed.length() >= ellipsis.length())
+                trimmed = trimmed.substring(0, trimmed.length() - ellipsis.length()) + ellipsis;
             else
                 trimmed = "";
         }

--- a/core/src/main/java/org/yggard/brokkgui/skin/GuiTextfieldSkin.java
+++ b/core/src/main/java/org/yggard/brokkgui/skin/GuiTextfieldSkin.java
@@ -43,7 +43,8 @@ public class GuiTextfieldSkin<T extends GuiTextfield> extends GuiBehaviorSkinBas
             }
             
             @Override
-            public String computeValue() {
+            public String computeValue() 
+            {
                 return trimTextToWidth(getModel().getPromptText(), getModel().getPromptEllipsisProperty().getValue(),
                         (int) (getModel().getWidth() - getModel().getTextPaddingProperty().getValue() * 2), 
                         BrokkGuiPlatform.getInstance().getGuiHelper());


### PR DESCRIPTION
- Typed text doesn't overflow anymore out of the textfield if too long
- Prompt text doesn't overflow anymore out of the textfield if too long
- Cursor is not displayed anymore if the textfield isn't focused
- Add keystrokes with CTRL key : 
         - CTRL + LEFT
         - CTRL + RIGHT
         - CTRL + SUPPR
         - CTRL + BACK